### PR TITLE
Patch 14 security advisories with conservative lockfile bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.2)
     async (2.24.0)
       console (~> 1.29)
@@ -32,7 +32,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.8)
     cgi (0.5.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.8)
     console (1.30.2)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -69,11 +69,12 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     event_stream_parser (1.0.0)
-    faraday (2.11.0)
-      faraday-net_http (>= 2.0, < 3.4)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
       logger
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.3.0)
       net-http
     fiber-annotation (0.2.0)
@@ -102,8 +103,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.8.3)
-    rexml (3.3.1)
-      strscan
+    rexml (3.4.4)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -155,7 +155,6 @@ GEM
       unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
-    strscan (3.1.0)
     thor (1.3.2)
     timecop (0.9.10)
     traces (0.15.2)
@@ -179,7 +178,7 @@ GEM
       tty-screen (~> 0.8)
     unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
-    uri (0.13.1)
+    uri (1.1.1)
     vcr (6.3.1)
       base64
     webmock (3.23.1)


### PR DESCRIPTION
## What

Lockfile-only security bump. `bundler-audit` flags 14 advisories across five gems in `Gemfile.lock`:

| Gem | Locked | Bumped | Advisories |
|---|---|---|---|
| faraday | 2.11.0 | 2.14.3 | SSRF via protocol-relative URLs (CVE-2026-25765 + incomplete-fix follow-up CVE-2026-33637), nested-params stack-exhaustion DoS (CVE-2026-54297) |
| uri | 0.13.1 | 1.1.1 | userinfo credential leakage (CVE-2025-27221) and its bypass (CVE-2025-61594) |
| concurrent-ruby | 1.3.4 | 1.3.8 | AtomicReference NaN livelock (CVE-2026-54904), RW-lock exclusivity bugs (CVE-2026-54905, CVE-2026-54906) |
| addressable | 2.8.7 | 2.9.0 | template ReDoS (CVE-2026-35611) |
| rexml | 3.3.1 | 3.4.4 | five DoS advisories (CVE-2024-39908 … CVE-2024-49761) |

faraday matters most: it's ruby-openai's transport, i.e. the path every LLM call takes. uri and concurrent-ruby are runtime-transitive; addressable and rexml are dev-only (webmock/rubocop).

A sixth gem moves with no advisory behind it: **faraday-multipart 1.0.4 → 1.2.0**. Its 1.0.4 gemspec declares `required_ruby_version < 4`, so a lock holding it cannot `bundle install` on current stable Ruby (4.x) at all — the panel caught it riding along undisclosed, and the root cause turned out to be exactly that ceiling. 1.2.0 lifts it and keeps the `Faraday::UploadIO` alias that ruby-openai 7.1.0's multipart path calls (verified present in 1.2.0's source). WORLD.md: "Track the latest stable Ruby."

## How

`bundle lock --update addressable rexml concurrent-ruby uri faraday faraday-multipart --conservative` — all six bumped in place. **ruby-openai stays at 7.1.0**; the gemspec is untouched and `Gemfile.lock` is excluded from the packaged gem, so consumers see nothing. This patches only the gem's own dev/CI resolution.

## Verification

- `bundler-audit check`: **No vulnerabilities found** (was 14)
- `bundle exec rake` (610 examples + standardrb): exit 0
- Caveat, stated plainly: local verification ran on **Ruby 4.0.6** (no 3.2 interpreter on this machine). CI's **3.2.4** run is the adjudicating evidence — it's where uri 1.1.1 activates as a gem over the 0.12.x default, the largest behavioral delta here. Please treat the green `Ruby 3.2.4` check, not the local run, as the merge evidence.

One review finding didn't block but is tracked: faraday ≥ 2.12 embeds the full request URL in error messages, which agentic's logger and execution journal persist verbatim — a query-string-auth exposure for custom `api_base_url` gateways. Filed as item 3 on #12 with a proposed sanitize-at-boundary fix.

## Panel

- **DHH** — cleared. "A Gemfile.lock-only conservative bump has no API surface to be un-Ruby-ish"; flagged the faraday-multipart drift and the uri major jump, judged both acceptable.
- **Obie Fernandez** — objected-then-cleared. Three objections: the undisclosed faraday-multipart bump, verification on the wrong Ruby, and faraday 2.14's URL-bearing error messages hitting persistent sinks. Second pass verified the fixes claim-by-claim (forced sixth bump disclosed, CI-as-evidence stated verbatim in the commit, no failure text reaches LLM prompts, exposure tracked on #12): "two faraday SSRF CVEs outrank a same-trust-domain local-log refinement."
- **Vladimir Dementyev** — objected-then-cleared. Two objections: the sixth bump and the 4.0.6-vs-3.2.4 evidence gap. Second pass independently confirmed faraday-multipart 1.0.4's `< 4` ruby ceiling forces the move, and ran `Faraday::UploadIO` resolution live under 1.2.0 to close the seam VCR can't see. "Refusing to peg a shared host's CPU building a second interpreter for evidence CI produces for free is the right performance call."
- **The gem consumer** — cleared. Verified `Gemfile.lock` is excluded from the packaged gem, gemspec constraints untouched, version.rb untouched: "the diff moves the single tested point, it doesn't change the contract surface."
