### PR TITLE
chore(deps): group Dependabot updates into a single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,14 @@ updates:
     schedule:
       interval: "weekly"
     labels: ["loop:deps"]
+    groups:
+      bundler:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels: ["loop:deps"]
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Dependabot was opening one PR per dependency. This adds a `groups` block matching `*` to every ecosystem in `.github/dependabot.yml`, so each weekly run produces one consolidated PR per ecosystem+directory instead of a stream of individual ones.

Note: a Dependabot group is scoped to one ecosystem + directory, so bundler and github-actions still open separate PRs — that's the floor, not a config miss. Grouping is also not retroactive; already-open individual PRs stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)