### PR TITLE
chore: dependabot monthly grouped batch + 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,26 @@
+# Dependabot: grouped monthly batch, 7-day cooldown, security updates stay immediate.
+# Per https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/
 version: 2
 updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels: ["loop:deps"]
+    cooldown:
+      default-days: 7
     groups:
-      bundler:
+      monthly-batch:
+        applies-to: version-updates
         patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels: ["loop:deps"]
+    cooldown:
+      default-days: 7
     groups:
-      github-actions:
+      monthly-batch:
+        applies-to: version-updates
         patterns: ["*"]


### PR DESCRIPTION
Applies the GitHub guidance in [Tame Dependabot: group your updates, slow the cadence, keep security fast](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/) (Val's intake, 2026-08-31).

- `schedule.interval: monthly` for bundler + github-actions (was weekly)
- one `monthly-batch` group per ecosystem, `applies-to: version-updates`, so all version bumps land as a single PR
- `cooldown.default-days: 7`: a new release must be a week old before Dependabot proposes it (dodges same-day bad releases)
- security updates are untouched: they stay ungrouped and immediate by default

Config-only; no workflow changes.