### PR TITLE
deps: raise Ruby floor to >= 3.2 and test a real CI matrix (#15)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - '3.2.4'
+        ruby: ['3.2', '3.3', '3.4', 'ruby']
 
     steps:
     - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Changed
+- **Ruby floor raised to 3.2** (`required_ruby_version = ">= 3.2"`). The old `>= 3.0.0` claim was never true: the locked `async 2.24` (and `console`, `io-event` through it) already require Ruby 3.1, and Ruby 3.0/3.1 are EOL. CI now tests 3.2, 3.3, 3.4 and latest stable instead of a single pinned 3.2.4. Closes #15.
+
 ## [0.3.0] - 2025-08-18
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "standard", "~> 1.3"
 gem "vcr"
 gem "webmock"
 gem "timecop"
+gem "benchmark" # bundled gem since Ruby 4.0; spec/performance requires it
 gem "simplecov", require: false
 gem "memory_profiler"
 gem "rgl", "~> 0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       metrics (~> 0.12)
       traces (~> 0.15)
     base64 (0.2.0)
+    benchmark (0.5.0)
     bigdecimal (3.1.8)
     cgi (0.5.2)
     concurrent-ruby (1.3.8)
@@ -203,6 +204,7 @@ PLATFORMS
 DEPENDENCIES
   agentic!
   async (<= 2.37.0)
+  benchmark
   console (<= 1.34.3)
   dry-configurable (<= 1.3.0)
   io-event (<= 1.11.2)

--- a/agentic.gemspec
+++ b/agentic.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Easily build, manage, deploy, and run self-contained purpose-driven AI Agents."
   spec.homepage = "https://github.com/codenamev/agentic"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/codenamev/agentic"


### PR DESCRIPTION
Closes #15. Accepted lean from the 2026-09-10 contract-calls batch.

- `agentic.gemspec`: `required_ruby_version` `>= 3.0.0` → `>= 3.2`. The old floor was never honest: locked `async 2.24` / `console` / `io-event` already require 3.1, and 3.0/3.1 are EOL.
- `.github/workflows/main.yml`: matrix `['3.2', '3.3', '3.4', 'ruby']` with `fail-fast: false`. Minor-version strings let setup-ruby pick the latest patch instead of freezing on 3.2.4.
- `CHANGELOG.md`: entry under a new `[Unreleased]` heading.

**Version number left alone on purpose.** `lib/agentic/version.rb` says `0.2.0` while `CHANGELOG.md` already has a `[0.3.0] - 2025-08-18` section, so I can't tell which number the "minor bump" lands as. Several accepted items (#10, #16, #20) are also minor-bump changes, so one release commit setting the number once seems cleaner than each PR guessing. Say the word and I'll bump here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)